### PR TITLE
add loose ztsd pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,7 @@ outputs:
         - cudatoolkit
         - grpc-cpp
         - libprotobuf
+        - zstd
       track_features:
         {{ "- arrow-cuda" if build_type == 'cuda' else "" }}
     requirements:
@@ -82,12 +83,13 @@ outputs:
         - snappy
         - thrift-cpp
         - zlib {{ zlib }}
-        - zstd
+        - zstd {{ zstd }}
       run:
         - {{ pin_compatible('numpy', lower_bound='1.16') }}
         - python {{ python }}
         - grpc-cpp {{ grpc_cpp }}
         - libprotobuf {{ protobuf }}
+        - zstd {{ zstd }}
       run_constrained:
         - arrow-cpp-proc * {{ build_ext }}
         - cudatoolkit >=10.2    #[build_type == 'cuda']

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: {{ checksum }}
 
 build:
-  number: 4
+  number: 5
   run_exports:
     - {{ pin_subpackage("arrow-cpp", max_pin="x.x.x") }}
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

This PR will force the runtime arrow dep for zstd to come from Open-CE, which will have a 1.4.* pin, which looks safe according to:
https://abi-laboratory.pro/?view=timeline&l=zstd

requires: https://github.com/open-ce/open-ce/pull/408

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
