### PR TITLE
loosen orc pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: {{ checksum }}
 
 build:
-  number: 5
+  number: 6
   run_exports:
     - {{ pin_subpackage("arrow-cpp", max_pin="x.x.x") }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,7 @@ outputs:
         - grpc-cpp
         - libprotobuf
         - zstd
+        - orc
       track_features:
         {{ "- arrow-cuda" if build_type == 'cuda' else "" }}
     requirements:
@@ -76,7 +77,7 @@ outputs:
         - libutf8proc
         - lz4-c
         - numpy {{ numpy }}
-        - orc
+        - orc 1.6.*
         - python {{ python }}
         - rapidjson
         - re2
@@ -90,6 +91,7 @@ outputs:
         - grpc-cpp {{ grpc_cpp }}
         - libprotobuf {{ protobuf }}
         - zstd {{ zstd }}
+        - orc 1.6.*
       run_constrained:
         - arrow-cpp-proc * {{ build_ext }}
         - cudatoolkit >=10.2    #[build_type == 'cuda']


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

This loosens the `orc` dependency to 1.6.* to allow for security fixes in orc and in other packages.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
