### PR TITLE
adjust cuda variant

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -101,7 +101,7 @@ outputs:
     about:
       home: http://github.com/apache/arrow
       license: Apache-2.0
-      license_File:
+      license_file:
         - LICENSE.txt
       summary: C++ libraries for Apache Arrow
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,8 @@ outputs:
     script: build-arrow.sh
     version: {{ version }}
     build:
-      string: py{{ CONDA_PY}}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ build_ext }}
+      string: py{{ CONDA_PY}}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ build_ext }}{{ cudatoolkit | replace(".*", "") }} #[build_type == 'cuda']
+      string: py{{ CONDA_PY}}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ build_ext }}  #[build_type == 'cpu']
 {% if build_type == 'cuda' %}
       script_env:
         - CUDA_HOME
@@ -69,6 +70,7 @@ outputs:
         - brotli
         - bzip2
         - c-ares
+        - cudatoolkit {{ cudatoolkit }}    #[build_type == 'cuda']
         - gflags
         - glog
         - grpc-cpp {{ grpc_cpp }}
@@ -87,6 +89,7 @@ outputs:
         - zstd {{ zstd }}
       run:
         - {{ pin_compatible('numpy', lower_bound='1.16') }}
+        - cudatoolkit {{ cudatoolkit }}    #[build_type == 'cuda']
         - python {{ python }}
         - grpc-cpp {{ grpc_cpp }}
         - libprotobuf {{ protobuf }}
@@ -94,7 +97,6 @@ outputs:
         - orc 1.6.*
       run_constrained:
         - arrow-cpp-proc * {{ build_ext }}
-        - cudatoolkit >=10.2    #[build_type == 'cuda']
 
     about:
       home: http://github.com/apache/arrow
@@ -138,7 +140,8 @@ outputs:
     script: build-pyarrow.sh
     version: {{ version }}
     build:
-      string: py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ build_ext }}
+      string: py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ build_ext }}{{ cudatoolkit | replace(".*", "") }} #[build_type == 'cuda']
+      string: py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ build_ext }}  #[build_type == 'cpu']
 {% if build_type == 'cuda' %}
       script_env:
         - CUDA_HOME
@@ -156,6 +159,7 @@ outputs:
         - {{ compiler('cxx') }}
       host:
         - {{ pin_subpackage('arrow-cpp', exact=True) }}
+        - cudatoolkit {{ cudatoolkit }}  # [build_type == 'cuda']
         - cython
         - numpy {{ numpy }}
         - python {{ python }}
@@ -166,10 +170,10 @@ outputs:
       run:
         - {{ pin_subpackage('arrow-cpp', exact=True) }}
         - {{ pin_compatible('numpy', lower_bound='1.16') }}
+        - cudatoolkit {{ cudatoolkit }}  # [build_type == 'cuda']
         - python {{ python }}
       run_constrained:
         - arrow-cpp-proc * {{ build_ext }}
-        - cudatoolkit >=10.2  # [build_type == 'cuda']
 
     about:
       home: http://github.com/apache/arrow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: {{ checksum }}
 
 build:
-  number: 6
+  number: 7
   run_exports:
     - {{ pin_subpackage("arrow-cpp", max_pin="x.x.x") }}
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

This PR changes the cuda build variant to be linked to the cuda version it was built with.
Technically since Arrow only uses libcuda (and not libcudart) this isn't necessary, and we could build against only the oldest cuda, but that scenario has little value in Open-CE where we could just as easily have multiple packages for each cuda version. There is less confusion this way.

example package names after this change:
```
arrow-cpp-3.0.0-py37hb240822_6_cuda10.2.tar.bz2
arrow-cpp-proc-3.0.0-cuda.tar.bz2
pyarrow-3.0.0-py37h0fe698a_6_cuda10.2.tar.bz2
```

example dependencies after this change:

```
track_features: 
  - arrow-cuda
constraints : 
  - arrow-cpp-proc * cuda
dependencies: 
  - brotli >=1.0.9,<2.0a0
  - bzip2 >=1.0.8,<2.0a0
  - c-ares >=1.17.1,<2.0a0
  - cudatoolkit 10.2.*
  - gflags >=2.2.2,<2.3.0a0
  - glog >=0.5.0,<0.6.0a0
  - grpc-cpp 1.29.*
  - libgcc-ng >=7.3.0
  - libprotobuf 3.11.2.*
  - libstdcxx-ng >=7.3.0
  - libthrift >=0.13.0,<0.14.0a0
  - libutf8proc >=2.6.1,<3.0a0
  - lz4-c >=1.9.3,<1.10.0a0
  - numpy >=1.16,<2.0a0
  - orc 1.6.*
  - python >=3.7,<3.8.0a0
  - re2 >=2020.11.1,<2020.11.2.0a0
  - snappy >=1.1.8,<2.0a0
  - zlib >=1.2.11,<1.3.0a0
  - zstd 1.4.*
```


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
