### PR TITLE
Add support for s390x

### DIFF
--- a/recipe/build-arrow.sh
+++ b/recipe/build-arrow.sh
@@ -60,6 +60,9 @@ fi
 if [[ "${target_platform}" == "linux-ppc64le" ]]; then
   EXTRA_CMAKE_ARGS=" ${EXTRA_CMAKE_ARGS} -DARROW_ALTIVEC=ON"
 fi
+if [[ "${target_platform}" != "linux-s390x" ]]; then
+  EXTRA_CMAKE_ARGS=" ${EXTRA_CMAKE_ARGS} -DARROW_USE_LD_GOLD=ON"
+fi
 
 # MAKE_CXX_FLAGS_RELEASE is being set to -O2 due to compiler errors seen with
 # GCC 7 on x86.
@@ -84,7 +87,6 @@ cmake \
     -DARROW_PLASMA=ON \
     -DARROW_PYTHON=ON \
     -DARROW_S3=OFF \
-    -DARROW_USE_LD_GOLD=ON \
     -DARROW_WITH_BROTLI=ON \
     -DARROW_WITH_BZ2=ON \
     -DARROW_WITH_LZ4=ON \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - 0300-ARROW-12917-C-Fix-handling-of-decimal-types-with-neg.patch
 
 build:
-  number: 10
+  number: 11
   run_exports:
     - {{ pin_subpackage("arrow-cpp", max_pin="x.x.x") }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -197,14 +197,12 @@ outputs:
         - libstdcxx-ng {{ libstdcxx }}
       run:
         - {{ pin_subpackage('arrow-cpp', exact=True) }}
-        - brotli  # [s390x]
         - {{ pin_compatible('numpy', lower_bound='1.16') }}
         - cudatoolkit {{ cudatoolkit }}  # [build_type == 'cuda']
         - python {{ python }}
         # Use pins to control cos6/cos7 match
         - libgcc-ng  {{ libgcc }}
         - libstdcxx-ng {{ libstdcxx }}
-        - libutf8proc  # [s390x]
       run_constrained:
         - arrow-cpp-proc * {{ build_ext }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,6 +60,7 @@ outputs:
         {{ "- arrow-cuda" if build_type == 'cuda' else "" }}
     requirements:
       build:
+        - abseil-cpp {{ abseil_cpp }}
         - libprotobuf {{ protobuf }}
         - grpc-cpp {{ grpc_cpp }}
         # to avoid https://gitlab.kitware.com/cmake/cmake/-/issues/18810
@@ -76,6 +77,7 @@ outputs:
       host:
         # Disable AWS S3 support
         #- aws-sdk-cpp
+        - abseil-cpp {{ abseil_cpp }}
         - boost-cpp {{ boost }}
         - brotli
         - bzip2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,7 +60,7 @@ outputs:
         {{ "- arrow-cuda" if build_type == 'cuda' else "" }}
     requirements:
       build:
-        - abseil-cpp {{ abseil_cpp }}
+        - abseil-cpp {{ abseil_cpp }} # [s390x]
         - libprotobuf {{ protobuf }}
         - grpc-cpp {{ grpc_cpp }}
         # to avoid https://gitlab.kitware.com/cmake/cmake/-/issues/18810
@@ -77,7 +77,7 @@ outputs:
       host:
         # Disable AWS S3 support
         #- aws-sdk-cpp
-        - abseil-cpp {{ abseil_cpp }}
+        - abseil-cpp {{ abseil_cpp }} # [s390x]
         - boost-cpp {{ boost }}
         - brotli
         - bzip2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,7 +62,9 @@ outputs:
       build:
         - libprotobuf {{ protobuf }}
         - grpc-cpp {{ grpc_cpp }}
-        - cmake 3.19   # to avoid https://gitlab.kitware.com/cmake/cmake/-/issues/18810
+        # to avoid https://gitlab.kitware.com/cmake/cmake/-/issues/18810
+        - cmake 3.19        # [not s390x]
+        - cmake {{ cmake }} # [s390x]
         - autoconf
         - ninja
         - make
@@ -83,7 +85,7 @@ outputs:
         - glog
         - grpc-cpp {{ grpc_cpp }}
         - libprotobuf {{ protobuf }}
-        - llvmdev 10
+        - llvmdev 10  # [not s390x]
         - libutf8proc
         - lz4-c
         - numpy {{ numpy }}
@@ -99,6 +101,7 @@ outputs:
         - libgcc-ng  {{ libgcc }}
         - libstdcxx-ng {{ libstdcxx }}
       run:
+        - brotli  # [s390x]
         - {{ pin_compatible('numpy', lower_bound='1.16') }}
         - cudatoolkit {{ cudatoolkit }}    #[build_type == 'cuda']
         - python {{ python }}
@@ -109,6 +112,7 @@ outputs:
         # Use pins to control cos6/cos7 match
         - libgcc-ng  {{ libgcc }}
         - libstdcxx-ng {{ libstdcxx }}
+        - libutf8proc  # [s390x]
       run_constrained:
         - arrow-cpp-proc * {{ build_ext }}
 
@@ -191,12 +195,14 @@ outputs:
         - libstdcxx-ng {{ libstdcxx }}
       run:
         - {{ pin_subpackage('arrow-cpp', exact=True) }}
+        - brotli  # [s390x]
         - {{ pin_compatible('numpy', lower_bound='1.16') }}
         - cudatoolkit {{ cudatoolkit }}  # [build_type == 'cuda']
         - python {{ python }}
         # Use pins to control cos6/cos7 match
         - libgcc-ng  {{ libgcc }}
         - libstdcxx-ng {{ libstdcxx }}
+        - libutf8proc  # [s390x]
       run_constrained:
         - arrow-cpp-proc * {{ build_ext }}
 


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description
To add support for s390x. As AnacondaRecipes has dependency on brotli and utf8proc in run section of meta.yaml in arrow-feedstock and in pyarrow-feedstock, I added them here for s390x.

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
