### PR TITLE
remove compiler pins as these are no longer needed

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,9 +71,6 @@ outputs:
         - make
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
-        # Use pins to control cos6/cos7 match
-        - libgcc-ng  {{ libgcc }}
-        - libstdcxx-ng {{ libstdcxx }}
       host:
         # Disable AWS S3 support
         #- aws-sdk-cpp
@@ -99,9 +96,6 @@ outputs:
         - thrift-cpp
         - zlib {{ zlib }}
         - zstd {{ zstd }}
-        # Use pins to control cos6/cos7 match
-        - libgcc-ng  {{ libgcc }}
-        - libstdcxx-ng {{ libstdcxx }}
       run:
         - brotli  # [s390x]
         - {{ pin_compatible('numpy', lower_bound='1.16') }}
@@ -174,9 +168,6 @@ outputs:
         - make
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
-        # Use pins to control cos6/cos7 match
-        - libgcc-ng  {{ libgcc }}
-        - libstdcxx-ng {{ libstdcxx }}
       host:
         - {{ pin_subpackage('arrow-cpp', exact=True) }}
         - cudatoolkit {{ cudatoolkit }}  # [build_type == 'cuda']
@@ -187,9 +178,6 @@ outputs:
         - setuptools_scm 5.0.2
         - setuptools-scm 5.0.2
         - six {{ six }}
-        # Use pins to control cos6/cos7 match
-        - libgcc-ng  {{ libgcc }}
-        - libstdcxx-ng {{ libstdcxx }}
       run:
         - {{ pin_subpackage('arrow-cpp', exact=True) }}
         - {{ pin_compatible('numpy', lower_bound='1.16') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - 0301-fix-option-to-disable-TLS-verification.patch
 
 build:
-  number: 13
+  number: 14
   run_exports:
     - {{ pin_subpackage("arrow-cpp", max_pin="x.x.x") }}
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Requires - open-ce/open-ce#501
Remove compiler pins as these are no longer required now, since we are moving to GCC 7.5 on x86.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
