### PR TITLE
Fix build for 1.3 and 1.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - 0301-fix-option-to-disable-TLS-verification.patch
 
 build:
-  number: 13
+  number: 14
   run_exports:
     - {{ pin_subpackage("arrow-cpp", max_pin="x.x.x") }}
 
@@ -60,7 +60,7 @@ outputs:
         {{ "- arrow-cuda" if build_type == 'cuda' else "" }}
     requirements:
       build:
-        - abseil-cpp {{ abseil_cpp }} # [s390x]
+        - abseil-cpp {{ abseil_cpp }}
         - libprotobuf {{ protobuf }}
         - grpc-cpp {{ grpc_cpp }}
         # to avoid https://gitlab.kitware.com/cmake/cmake/-/issues/18810
@@ -77,7 +77,7 @@ outputs:
       host:
         # Disable AWS S3 support
         #- aws-sdk-cpp
-        - abseil-cpp {{ abseil_cpp }} # [s390x]
+        - abseil-cpp {{ abseil_cpp }}
         - boost-cpp {{ boost }}
         - brotli
         - bzip2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,8 +72,8 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         # Use pins to control cos6/cos7 match
-        - libgcc-ng  {{ libgcc }}
-        - libstdcxx-ng {{ libstdcxx }}
+        - libgcc-ng  {{ libgcc }}          # [x86_64 and c_compiler_version == "7.2.*"]
+        - libstdcxx-ng {{ libstdcxx }}     # [x86_64 and c_compiler_version == "7.2.*"]
       host:
         # Disable AWS S3 support
         #- aws-sdk-cpp
@@ -100,8 +100,9 @@ outputs:
         - zlib {{ zlib }}
         - zstd {{ zstd }}
         # Use pins to control cos6/cos7 match
-        - libgcc-ng  {{ libgcc }}
-        - libstdcxx-ng {{ libstdcxx }}
+        - libgcc-ng  {{ libgcc }}          # [x86_64 and c_compiler_version == "7.2.*"]
+        - libstdcxx-ng {{ libstdcxx }}     # [x86_64 and c_compiler_version == "7.2.*"]
+        - openssl 1.1.1k                   # [x86_64 and c_compiler_version == "7.2.*"]
       run:
         - brotli  # [s390x]
         - {{ pin_compatible('numpy', lower_bound='1.16') }}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

The latest openssl packages on x86 have been built with the new Anaconda toolchain.
This PR will pin to an older openSSL at build time when using the old toolchain and allow newer SSLs when using the newer toolchain.

closes #19 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
